### PR TITLE
fix loginPage configuration utilize registrationId rather than realm

### DIFF
--- a/src/main/java/ac/simons/keycloakdemo/DemoApplication.java
+++ b/src/main/java/ac/simons/keycloakdemo/DemoApplication.java
@@ -54,7 +54,7 @@ class SecurityConfig {
      */
     @Bean
     public WebSecurityConfigurerAdapter webSecurityConfigurer(
-        @Value("${keycloak-client.realm}") final String realm
+        @Value("${keycloak-client.registration-id}") final String registrationId
     ) {
         return new WebSecurityConfigurerAdapter() {
             @Override
@@ -76,7 +76,7 @@ class SecurityConfig {
                         // I don't want a page with different clients as login options
                         // So i use the constant from OAuth2AuthorizationRequestRedirectFilter
                         // plus the configured realm as immediate redirect to Keycloak
-                        .loginPage(DEFAULT_AUTHORIZATION_REQUEST_BASE_URI + "/" + realm);
+                        .loginPage(DEFAULT_AUTHORIZATION_REQUEST_BASE_URI + "/" + registrationId);
             }
         };
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,7 @@ server:
 keycloak-client:
   server-url: http://localhost:8080/auth
   realm: test
+  registration-id: my-keycloak
 
 spring:
   security:
@@ -11,7 +12,7 @@ spring:
       client:
         registration:
           # This 'Demo:' is the id used inside the redirect-uri-template and must be the same as your realm
-          test: 
+          my-keycloak:
             client-id: test-app
             client-secret: a0fe1b28-02f1-4751-a4eb-a72f78882a47
             client-name: some client


### PR DESCRIPTION
The web security configuration gets realm property injected to construct a login page configuration.
However, the registration id is the base for the correct login page address, not the realm name.
The example worked by coincidence, since the realm name matched the registration id.
This commit fixes the configuration by renaming the registration id uniquely and changing login page configuration to use it.